### PR TITLE
Remove leading space in maptPathRelativeTo

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,8 +75,7 @@ var fromSource = exports.fromSource = function (source) {
 
 function mapPathRelativeTo (root) {
   return function map(file) {
-    // add leading space here since devtools cuts off first char
-    return ' ' + path.relative(root, file);
+    return path.relative(root, file);
   };
 }
 


### PR DESCRIPTION
The leading space causes problems for node-source-map-support and Chrome DevTools no longer strips the first character.
