### PR TITLE
Fix non-destructive pipethrough of source when no sourcemap exists

### DIFF
--- a/examples/project/js/main.js
+++ b/examples/project/js/main.js
@@ -1,4 +1,4 @@
 console.log('main line 1');
 var foo = require('./foo.js');
 
-foo();
+foo(null);

--- a/index.js
+++ b/index.js
@@ -89,7 +89,10 @@ exports.transform = function (fn) {
     var sourceMolder = fromSource(source);
 
     function queue(adaptedComment) {
-      this.queue(source.replace(sourceMolder.comment, adaptedComment));
+      var newSource = (sourceMolder.comment)
+         ? source.replace(sourceMolder.comment, adaptedComment)
+         : source;
+      this.queue(newSource);
       this.queue(null);
     }
 

--- a/test/transform.js
+++ b/test/transform.js
@@ -34,6 +34,28 @@ test('mold transform async', function (t) {
     });
 });
 
+test('mold transform async without sourcemap present', function (t) {
+  t.plan(3)
+  var bundle = '';
+  var originalSource;
+  browserify({ debug: false })
+    .require(require.resolve('../examples/project/js/main.js'), { entry: true })
+    .bundle()
+    .pipe(mold.transform(function(src, write) {
+      originalSource = src.source;
+      write(src.source);
+    }))
+    .on('error', function (err) { console.error(err); })
+    .on('data', function (data) {
+      bundle += data;
+    })
+    .on('end', function () {
+      t.notOk(~bundle.indexOf('application/json'), 'no inline sourcemap')
+      t.notOk(~bundle.indexOf('//@ sourceMappingURL=/bundle.js.map'), 'no external sourcemap')
+      t.equal(bundle, originalSource, 'source piped trough without modification')
+    });
+});
+
 test('mold transform sync', function (t) {
   t.plan(2)
   var bundle = '';


### PR DESCRIPTION
When no source map exists in the input file, sourceMolder.comment is set to
null. Therefore, when queue is called on line 91, the needle for str.replace is
`null` which gets string cast into `"null"`. That causes the first instance of
the `null` token in the source code to get replaced with whatever was passed
into the callback.

This commit includes a test to replicate the behavior and a fix. The fix works
by checking for the existence of the sourcemap comment before running the
replace functionality.