### PR TITLE
Use concat-stream for buffering stream contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "homepage": "https://github.com/thlorenz/mold-source-map",
   "dependencies": {
+    "concat-stream": "^1.5.1",
     "convert-source-map": "^1.1.0",
+    "duplexer": "^0.1.1",
     "through": "~2.2.7"
   },
   "devDependencies": {


### PR DESCRIPTION
We are running into an issue where occasionally a surrogate pair in our bundle is being split and the string concatenation method used here is causing the output to be invalid. This switches the buffering to be done with `concat-stream` so that it is operating on the raw buffers and only converted to a string once it is complete.