### PR TITLE
Remove invalid "main" entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "mold-source-map",
   "version": "0.4.0",
   "description": "Mold a source map that is almost perfect for you into one that is.",
-  "main": "mold-source-map.js",
   "scripts": {
     "test": "tap test/*.js"
   },


### PR DESCRIPTION
This points to a file which does not exist. Since the package contains
an index.js file, it is not necessary to specify a "main" module.

The invalid entry caused an error when trying to use yarn's [Plug 'n Play mode](https://github.com/yarnpkg/rfcs/pull/101) to install dependencies for an app which had mold-source-map as a transitive dependency.

Fixes #12